### PR TITLE
feat(mcp): 新增 debug_attach_pid，修复 attach 十进制 PID (.PID)

### DIFF
--- a/ATTACH.md
+++ b/ATTACH.md
@@ -1,0 +1,42 @@
+# `debug_attach_pid` — attach to a running process (MCP)
+
+## Summary
+
+Adds MCP tool **`debug_attach_pid`** so agents can attach x32dbg to an already-running process **without** `x32dbg.exe -p` or GUI Attach.
+
+**Root cause fixed:** x64dbg parses command-line numbers as **hex by default**. `attach 3580` attaches to PID `0x3580`, not decimal 3580. This plugin uses **`attach .%u`** (decimal PID per [Values](https://help.x64dbg.com/en/latest/introduction/Values.html)).
+
+**Implementation:** Queue plugin command `mcpattach .PID` → run on x64dbg command thread → `DbgCmdExecDirect("attach .PID")` → wait for `DbgIsDebugging()`.
+
+There is **no** `attachbreak` command in x64dbg; `attach_break` only optionally waits for pause after attach (often times out while game keeps `running` — attach still succeeds).
+
+## MCP tool
+
+| Tool | Args |
+|------|------|
+| `debug_attach_pid` | `pid` (decimal), `timeout_ms`, `attach_break`, `detach_first` |
+
+## Build (no vcpkg required)
+
+```powershell
+powershell -File build-x86.ps1
+# -> dist\x32dbg_mcp.dp32
+```
+
+Uses **FetchContent** for `nlohmann_json` when vcpkg is absent.
+
+## Verified (Windows, x32dbg 32-bit)
+
+- Empty debugger + `debug_attach_pid` → `main_nocd.exe` / `cmd.exe`, `module_get_main` OK
+- Log: `AttachProcessCore: attach .<pid> (decimal pid)`
+
+## Not recommended
+
+- `script_execute` with `attach <pid>` — returns success before attach completes; misleading
+- `attach <pid>` without `.` prefix — wrong PID on hex-default parser
+
+## Upstream PR notes
+
+- Tested for automation (Cursor MCP); PonPon game workflow uses LEProc + inject + `debug_attach_pid`
+- GUI Attach and `-p` remain valid fallbacks
+- Maintainer merge may prefer squashing `mcpattach` into internal attach path only (no extra plugin commands)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(x64dbg_mcp VERSION 1.0.7 LANGUAGES CXX RC)
+project(x64dbg_mcp VERSION 1.0.8 LANGUAGES CXX RC)
 
 # C++17 标准
 set(CMAKE_CXX_STANDARD 17)
@@ -42,8 +42,19 @@ else()
     message(FATAL_ERROR "Bundled xdbg SDK not found at: ${XDBG_BUNDLED_SDK_DIR} (set XDBG_SDK_DIR to override)")
 endif()
 
-# 第三方库 - 使用 vcpkg 引入 nlohmann_json
-find_package(nlohmann_json CONFIG REQUIRED)
+# nlohmann_json — vcpkg 或 FetchContent（无 vcpkg 时自动下载）
+find_package(nlohmann_json CONFIG QUIET)
+if(NOT nlohmann_json_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        nlohmann_json
+        URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+    message(STATUS "Using FetchContent nlohmann_json")
+else()
+    message(STATUS "Using vcpkg nlohmann_json")
+endif()
 
 # 源文件
 set(CORE_SOURCES

--- a/PR_UPSTREAM.md
+++ b/PR_UPSTREAM.md
@@ -1,0 +1,45 @@
+# Pull Request 正文（复制到 GitHub PR 描述框）
+
+## Summary
+
+Adds MCP tool **`debug_attach_pid`** to attach x32dbg/x64dbg to an **already running** process from automation (Cursor / MCP clients), without `x32dbg.exe -p` or GUI Attach.
+
+Fixes a subtle but critical bug: x64dbg command-line numbers are **hex by default**. `attach 3580` attaches to PID `0x3580`, not decimal 3580. This change uses **`attach .%u`** (decimal PID per [Values](https://help.x64dbg.com/en/latest/introduction/Values.html)).
+
+## Problem
+
+- `script_execute` with `attach <pid>` often returns **success before attach completes**; `debug_get_state: stopped` can mean **not debugging**.
+- Plain `attach <decimal_pid>` targets the wrong process on hex-default parsing.
+- There is **no** `attachbreak` command in x64dbg.
+
+## Solution
+
+- New MCP tool: `debug_attach_pid` (`pid`, `timeout_ms`, `attach_break`, `detach_first`).
+- Plugin commands on the **command thread**: `mcpattach .PID`, `mcpattachbreak .PID`, `mcpdetach`.
+- `DebugController::AttachProcessCore` → `DbgCmdExecDirect("attach .%u")` + wait for `DbgIsDebugging()`.
+- Optional: CMake **FetchContent** for `nlohmann_json` when vcpkg is absent (`build-x86.ps1`).
+
+## Tested
+
+- Windows 10, x32dbg 32-bit, plugin `1.0.8-attach`.
+- Empty debugger → `debug_attach_pid` → `module_get_main` / `breakpoint_set` OK.
+- Log line: `AttachProcessCore: attach .<pid> (decimal pid)`.
+
+## Known limitations
+
+- `attach_break: true` may **timeout** waiting for pause while the target keeps running; attach still succeeds in practice.
+- Error codes / failure messages not fully polished.
+- Does not fix misleading success of legacy `script_execute attach` (separate issue).
+
+## Docs
+
+See **`ATTACH.md`** in this PR.
+
+## Files (main)
+
+- `src/business/DebugController.cpp`, `DebugController.h`
+- `src/handlers/DebugHandler.cpp`, `DebugHandler.h`
+- `src/core/MCPToolRegistry.cpp`
+- `src/PluginEntry.cpp`
+- `ATTACH.md`
+- `CMakeLists.txt`, `build-x86.ps1` (optional build path)

--- a/PR_UPSTREAM_CN.md
+++ b/PR_UPSTREAM_CN.md
@@ -1,0 +1,43 @@
+## 概述
+
+新增 MCP 工具 **`debug_attach_pid`**：在 x32dbg/x64dbg **已打开、未附加** 时，由自动化（Cursor 等）附加到**已在运行**的进程，无需 `x32dbg.exe -p` 或 GUI「附加」。
+
+同时修复一个容易踩坑的问题：x64dbg 命令行里**数字默认按十六进制解析**。`attach 3580` 实际附加的是 PID `0x3580`，不是十进制 3580。本 PR 统一使用 **`attach .%u`**（`.` 表示十进制，见[官方 Values 文档](https://help.x64dbg.com/en/latest/introduction/Values.html)）。
+
+## 背景问题
+
+- 用 `script_execute` 执行 `attach <pid>` 时，经常**命令还没真正附加完就返回 success**；此时 `debug_get_state: stopped` 也可能只是**未在调试**。
+- 直接 `attach <十进制PID>` 在默认解析下会附到错误进程。
+- x64dbg **没有** `attachbreak` 这条命令（已移除相关错误用法）。
+
+## 实现要点
+
+- 新 MCP 工具：`debug_attach_pid`（参数：`pid`、`timeout_ms`、`attach_break`、`detach_first`）。
+- 在 **x64dbg 命令线程** 执行插件命令：`mcpattach .PID` / `mcpattachbreak .PID` / `mcpdetach`。
+- `DebugController::AttachProcessCore` → `DbgCmdExecDirect("attach .%u")`，并等待 `DbgIsDebugging()` 为真。
+- 可选：无 vcpkg 时用 CMake **FetchContent** 拉 `nlohmann_json`（`build-x86.ps1` 辅助 x86 构建）。
+
+## 实测环境
+
+- Windows 10，x32dbg 32 位，插件版本 `1.0.8-attach`。
+- 空载调试器 → `debug_attach_pid` → `module_get_main`、`breakpoint_set` 正常。
+- 日志可见：`AttachProcessCore: attach .<pid> (decimal pid)`。
+
+## 已知限制
+
+- `attach_break: true` 时，目标若一直 **running**，`WaitForPause` 可能超时，但**附加本身通常已成功**；自动化场景建议 `attach_break: false`。
+- 失败时的错误码/文案尚未完全打磨。
+- 未在本 PR 中单独修复旧版 `script_execute attach` 的“假成功”语义（可另开 issue）。
+
+## 文档
+
+详见本 PR 中的 **`ATTACH.md`**（英文技术说明，含构建与 API 表）。
+
+## 主要改动文件
+
+- `src/business/DebugController.cpp` / `.h`
+- `src/handlers/DebugHandler.cpp` / `.h`
+- `src/core/MCPToolRegistry.cpp`
+- `src/PluginEntry.cpp`
+- `ATTACH.md`
+- `CMakeLists.txt`、`build-x86.ps1`（可选无 vcpkg 构建路径）

--- a/build-x86.ps1
+++ b/build-x86.ps1
@@ -1,0 +1,28 @@
+# Setsuna MCP x86 build (pip cmake + VS2022 BuildTools)
+$ErrorActionPreference = 'Stop'
+$root = $PSScriptRoot
+$cmake = 'C:\Users\93202\AppData\Roaming\Python\Python314\Scripts\cmake.exe'
+if (-not (Test-Path $cmake)) { throw "cmake not found: $cmake" }
+
+$vcvars = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars32.bat"
+if (-not (Test-Path $vcvars)) { throw "vcvars32 not found: $vcvars" }
+
+cmd /c "`"$vcvars`" && set" | ForEach-Object {
+    if ($_ -match '^(.*?)=(.*)$') { Set-Item -Path "env:$($matches[1])" -Value $matches[2] }
+}
+
+Set-Location $root
+if (-not (Test-Path dist)) { New-Item -ItemType Directory -Path dist | Out-Null }
+
+Write-Host '=== CMake configure x86 ==='
+& $cmake -B build_x86 -G 'Visual Studio 17 2022' -A Win32 -DCMAKE_BUILD_TYPE=Release -DXDBG_ARCH=x86
+if ($LASTEXITCODE -ne 0) { throw 'configure failed' }
+
+Write-Host '=== CMake build x86 ==='
+& $cmake --build build_x86 --config Release -j
+if ($LASTEXITCODE -ne 0) { throw 'build failed' }
+
+$out = Join-Path $root 'build_x86\bin\Release\x32dbg_mcp.dp32'
+if (-not (Test-Path $out)) { throw "output missing: $out" }
+Copy-Item $out (Join-Path $root 'dist\x32dbg_mcp.dp32') -Force
+Write-Host "[OK] dist\x32dbg_mcp.dp32"

--- a/src/PluginEntry.cpp
+++ b/src/PluginEntry.cpp
@@ -27,12 +27,14 @@
 #include "utils/StringUtils.h"
 #include "communication/MCPHttpServer.h"
 #include "ui/ConfigEditor.h"
+#include "_plugins.h"
 #include <windows.h>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
 // 鎻掍欢鐗堟湰淇℃�?
-#define PLUGIN_VERSION "1.0.7"
+#define PLUGIN_VERSION "1.0.8-attach"
 
 // 鍙�?CMake 瑕嗙洊锛歅LUGIN_DISPLAY_NAME, PLUGIN_DIR_NAME
 #ifndef PLUGIN_DISPLAY_NAME
@@ -426,6 +428,62 @@ static void RegisterAllMethods() {
 /**
  * @brief 娉ㄥ唽鎵€鏈夊洖�?
  */
+namespace MCP {
+
+static uint32_t ParsePidArg(const char* text) {
+    if (text == nullptr || *text == '\0') {
+        return 0;
+    }
+    char* end = nullptr;
+    unsigned long value = 0;
+    if (*text == '.') {
+        value = std::strtoul(text + 1, &end, 10);
+    } else {
+        value = std::strtoul(text, &end, 10);
+    }
+    if (end == text || *end != '\0' || value == 0 || value > UINT32_MAX) {
+        return 0;
+    }
+    return static_cast<uint32_t>(value);
+}
+
+static bool CmdMcpAttach(int argc, char** argv) {
+    if (argc < 2) {
+        return false;
+    }
+    const uint32_t pid = ParsePidArg(argv[1]);
+    if (pid == 0) {
+        return false;
+    }
+    return DebugController::Instance().AttachProcessCore(pid, false, true);
+}
+
+static bool CmdMcpAttachBreak(int argc, char** argv) {
+    if (argc < 2) {
+        return false;
+    }
+    const uint32_t pid = ParsePidArg(argv[1]);
+    if (pid == 0) {
+        return false;
+    }
+    return DebugController::Instance().AttachProcessCore(pid, true, true);
+}
+
+static bool CmdMcpDetach(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    return DebugController::Instance().DetachProcessCore();
+}
+
+} // namespace MCP
+
+static void RegisterPluginCommands() {
+    _plugin_registercommand(g_pluginHandle, "mcpattach", MCP::CmdMcpAttach, false);
+    _plugin_registercommand(g_pluginHandle, "mcpattachbreak", MCP::CmdMcpAttachBreak, false);
+    _plugin_registercommand(g_pluginHandle, "mcpdetach", MCP::CmdMcpDetach, false);
+    MCP::Logger::Info("Registered plugin commands: mcpattach, mcpattachbreak, mcpdetach");
+}
+
 static void RegisterCallbacks() {
     _plugin_registercallback(g_pluginHandle, CB_INITDEBUG, MCP::CB_InitDebug);
     _plugin_registercallback(g_pluginHandle, CB_STOPDEBUG, MCP::CB_StopDebug);
@@ -435,7 +493,8 @@ static void RegisterCallbacks() {
     _plugin_registercallback(g_pluginHandle, CB_EXITPROCESS, MCP::CB_ExitProcess);
     _plugin_registercallback(g_pluginHandle, CB_LOADDLL, MCP::CB_LoadDll);
     _plugin_registercallback(g_pluginHandle, CB_UNLOADDLL, MCP::CB_UnloadDll);
-    _plugin_registercallback(g_pluginHandle, CB_MENUENTRY, MCP::CB_MenuEntry);  // 娉ㄥ唽鑿滃崟鍥炶�?
+    _plugin_registercallback(g_pluginHandle, CB_MENUENTRY, MCP::CB_MenuEntry);
+    RegisterPluginCommands();  // 娉ㄥ唽鑿滃崟鍥炶�?
     
     MCP::Logger::Info("All callbacks registered");
 }
@@ -645,6 +704,10 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct) {
  */
 extern "C" __declspec(dllexport) void plugstop() {
     MCP::Logger::Info("Plugin stopping...");
+
+    _plugin_unregistercommand(g_pluginHandle, "mcpattach");
+    _plugin_unregistercommand(g_pluginHandle, "mcpattachbreak");
+    _plugin_unregistercommand(g_pluginHandle, "mcpdetach");
     
     // 鍋滄�?MCP HTTP 鏈嶅姟鍣?
     try {

--- a/src/business/DebugController.cpp
+++ b/src/business/DebugController.cpp
@@ -4,6 +4,7 @@
 #include "../core/Exceptions.h"
 #include "../core/X64DBGBridge.h"
 #include <limits>
+#include <windows.h>
 
 namespace MCP {
 
@@ -332,6 +333,172 @@ bool DebugController::Init(const std::string& path,
     return success;
 }
 
+bool DebugController::DetachProcessCore() {
+    if (!IsDebugging()) {
+        return true;
+    }
+    Logger::Debug("DetachProcessCore: detach/stop");
+    ExecuteCommandDirect("detach");
+    Sleep(200);
+    if (IsDebugging()) {
+        ExecuteCommandDirect("stop");
+        Sleep(200);
+    }
+    return !IsDebugging();
+}
+
+bool DebugController::AttachProcessCore(uint32_t pid, bool useAttachBreak, bool detachFirst) {
+    if (pid == 0) {
+        return false;
+    }
+
+    if (IsDebugging()) {
+        const uint32_t currentPid = GetDebuggeeProcessId();
+        if (currentPid == pid) {
+            Logger::Info("AttachProcessCore: already on pid {}", pid);
+            return true;
+        }
+        if (!detachFirst) {
+            Logger::Error("AttachProcessCore: busy with pid {}, want {}", currentPid, pid);
+            return false;
+        }
+        if (!DetachProcessCore()) {
+            Logger::Error("AttachProcessCore: detach failed");
+            return false;
+        }
+    }
+
+    // x64dbg 命令行整数默认为十六进制；十进制 PID 必须用 ".1234" 形式（见 Values 文档）
+    char command[64] = {};
+    sprintf_s(command, "attach .%u", pid);
+    (void)useAttachBreak;
+
+    Logger::Info("AttachProcessCore: {} (decimal pid)", command);
+    if (!ExecuteCommandDirect(command)) {
+        Logger::Error("AttachProcessCore: direct command failed");
+        return false;
+    }
+
+    return IsDebugging();
+}
+
+bool DebugController::AttachProcess(uint32_t pid,
+                                    uint32_t timeoutMs,
+                                    bool useAttachBreak,
+                                    bool detachIfBusy) {
+    if (pid == 0) {
+        Logger::Error("AttachProcess: invalid pid 0");
+        return false;
+    }
+
+    // 轻量校验：存在即可；真正 OpenProcess(PROCESS_ALL_ACCESS) 在 x64dbg attach 命令内完成
+    HANDLE processHandle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+    if (processHandle == nullptr || processHandle == INVALID_HANDLE_VALUE) {
+        processHandle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    }
+    if (processHandle == nullptr || processHandle == INVALID_HANDLE_VALUE) {
+        Logger::Warning(
+            "AttachProcess: OpenProcess probe failed for pid {} (error {}), trying attach anyway",
+            pid,
+            GetLastError()
+        );
+    } else {
+        DWORD exitCode = STILL_ACTIVE;
+        if (GetExitCodeProcess(processHandle, &exitCode) && exitCode != STILL_ACTIVE) {
+            CloseHandle(processHandle);
+            Logger::Error("AttachProcess: pid {} already exited (code {})", pid, exitCode);
+            return false;
+        }
+        CloseHandle(processHandle);
+    }
+
+    if (IsDebugging()) {
+        const uint32_t currentPid = GetDebuggeeProcessId();
+        if (currentPid == pid) {
+            Logger::Info("AttachProcess: already attached to pid {}", pid);
+            return true;
+        }
+        if (!detachIfBusy) {
+            Logger::Error("AttachProcess: already debugging pid {}, requested {}", currentPid, pid);
+            return false;
+        }
+        Logger::Debug("AttachProcess: detaching before attach");
+        if (!ExecuteCommand("mcpdetach")) {
+            Logger::Error("AttachProcess: mcpdetach enqueue failed");
+            return false;
+        }
+        const uint32_t waitMs = timeoutMs > 0 ? timeoutMs : 15000;
+        auto start = std::chrono::steady_clock::now();
+        while (IsDebugging()) {
+            PumpGuiMessages();
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start).count();
+            if (elapsed >= waitMs) {
+                Logger::Error("AttachProcess: detach timed out");
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    char pluginCmd[32] = {};
+    sprintf_s(pluginCmd, "mcpattach .%u", pid);
+    (void)useAttachBreak;
+    Logger::Info("AttachProcess: queue {}", pluginCmd);
+    if (!ExecuteCommand(pluginCmd)) {
+        Logger::Error("AttachProcess: plugin command enqueue failed");
+        return false;
+    }
+
+    const uint32_t waitMs = timeoutMs > 0 ? timeoutMs : 30000;
+    if (!WaitForDebugging(waitMs)) {
+        Logger::Error("AttachProcess: DbgIsDebugging still false after {} ms", waitMs);
+        return false;
+    }
+
+    // attach 后通常在系统断点暂停；attach_break 仅表示多等一等暂停态
+    if (useAttachBreak && !WaitForPause(waitMs)) {
+        Logger::Warning(
+            "AttachProcess: WaitForPause timed out after {} ms (running={})",
+            waitMs,
+            DbgIsRunning()
+        );
+    }
+
+    const uint32_t attachedPid = GetDebuggeeProcessId();
+    if (attachedPid != 0 && attachedPid != pid) {
+        Logger::Warning("AttachProcess: requested pid {} but debugger reports pid {}", pid, attachedPid);
+    }
+
+    try {
+        Logger::Info(
+            "AttachProcess: ok pid={} rip=0x{:X} state={}",
+            attachedPid != 0 ? attachedPid : pid,
+            GetInstructionPointer(),
+            static_cast<int>(GetState())
+        );
+    } catch (...) {
+        Logger::Info("AttachProcess: ok pid={}", attachedPid != 0 ? attachedPid : pid);
+    }
+
+    return true;
+}
+
+uint32_t DebugController::GetDebuggeeProcessId() const {
+    if (!IsDebugging()) {
+        return 0;
+    }
+
+    duint pid = DbgValFromString("$pid");
+    if (pid == 0) {
+        pid = DbgValFromString("pid");
+    }
+    if (pid == 0 || pid > std::numeric_limits<uint32_t>::max()) {
+        return 0;
+    }
+    return static_cast<uint32_t>(pid);
+}
+
 std::string DebugController::GetLastDebuggedPath() const {
     return LoadLastDebuggedPath();
 }
@@ -382,10 +549,64 @@ bool DebugController::ExecuteCommand(const std::string& command) {
     return result;
 }
 
+bool DebugController::ExecuteCommandDirect(const std::string& command) {
+    Logger::Trace("Executing command (direct): {}", command);
+
+    bool result = DbgCmdExecDirect(command.c_str());
+
+    if (!result) {
+        Logger::Error("Direct command failed: {}", command);
+    }
+
+    return result;
+}
+
+void DebugController::PumpGuiMessages() {
+#ifdef XDBG_SDK_AVAILABLE
+    // Qt 主循环不会仅靠 PeekMessage 推进；刷新 GUI 以处理异步入队的 dbg 命令
+    DbgUpdateGui(0, false);
+
+    HWND hwnd = GuiGetWindowHandle();
+    if (hwnd == nullptr) {
+        return;
+    }
+
+    MSG msg = {};
+    while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+#endif
+}
+
+bool DebugController::WaitForDebugging(uint32_t timeoutMs) {
+    auto start = std::chrono::steady_clock::now();
+
+    while (true) {
+        PumpGuiMessages();
+
+        if (IsDebugging()) {
+            return true;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+
+        if (elapsed >= timeoutMs) {
+            Logger::Warning("Wait for debugging timed out after {} ms", timeoutMs);
+            return false;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
 bool DebugController::WaitForPause(uint32_t timeoutMs) {
     auto start = std::chrono::steady_clock::now();
     
     while (true) {
+        PumpGuiMessages();
+
         if (IsPaused()) {
             return true;
         }

--- a/src/business/DebugController.h
+++ b/src/business/DebugController.h
@@ -96,6 +96,28 @@ public:
               const std::string& currentDir = "");
 
     /**
+     * @brief 附加到已运行的进程（LEProc 冷启 + 注入后的 MAIN_NoCD 等）
+     *
+     * 使用 DbgCmdExec("attach PID") + WaitForPause，并校验 DbgIsDebugging。
+     * 不要用 script_execute attach（无等待、易假成功）。
+     */
+    bool AttachProcess(uint32_t pid,
+                       uint32_t timeoutMs = 15000,
+                       bool useAttachBreak = false,
+                       bool detachIfBusy = true);
+
+    /** 在 x64dbg 命令线程执行的真实 attach（供 mcpattach / mcpattachbreak 调用） */
+    bool AttachProcessCore(uint32_t pid, bool useAttachBreak, bool detachFirst);
+
+    /** 在命令线程 detach/stop（供 mcpdetach 调用） */
+    bool DetachProcessCore();
+
+    /**
+     * @brief 当前被调试进程 PID（来自 x64dbg $pid），未调试时返回 0
+     */
+    uint32_t GetDebuggeeProcessId() const;
+
+    /**
      * @brief 获取上次加载过的调试目标路径
      */
     std::string GetLastDebuggedPath() const;
@@ -128,6 +150,9 @@ private:
     DebugController& operator=(const DebugController&) = delete;
     
     bool ExecuteCommand(const std::string& command);
+    bool ExecuteCommandDirect(const std::string& command);
+    static void PumpGuiMessages();
+    bool WaitForDebugging(uint32_t timeoutMs);
     bool WaitForPause(uint32_t timeoutMs = 5000);
 
     mutable std::mutex m_lastPathMutex;

--- a/src/core/MCPToolRegistry.cpp
+++ b/src/core/MCPToolRegistry.cpp
@@ -237,6 +237,18 @@ void MCPToolRegistry::RegisterDefaultTools() {
     });
 
     RegisterTool({
+        "debug_attach_pid",
+        "Attach debugger to an already-running process by PID. Uses DbgCmdExec(attach) + WaitForPause + DbgIsDebugging check. Prefer over script_execute('attach'). For PonPon: LEProc start + inject first, x32dbg already open.",
+        "debug.attach_pid",
+        {
+            {"pid", "integer", "Target process ID (e.g. MAIN_NoCD.EXE after inject)", true, nullptr, nullptr},
+            {"timeout_ms", "integer", "Max wait for pause after attach (default 15000)", false, 15000, nullptr},
+            {"attach_break", "boolean", "After attach, wait until paused at system breakpoint (default false)", false, false, nullptr},
+            {"detach_first", "boolean", "Detach/stop current session before attach if busy (default true)", false, true, nullptr}
+        }
+    });
+
+    RegisterTool({
         "debug_stop",
         "Stop debugging and close target process",
         "debug.stop",

--- a/src/handlers/DebugHandler.cpp
+++ b/src/handlers/DebugHandler.cpp
@@ -5,6 +5,8 @@
 #include "../core/Logger.h"
 #include "../utils/StringUtils.h"
 #include <windows.h>
+#include <cstdlib>
+#include <limits>
 
 namespace MCP {
 
@@ -20,6 +22,7 @@ void DebugHandler::RegisterMethods() {
     dispatcher.RegisterMethod("debug.run_to", RunTo);
     dispatcher.RegisterMethod("debug.restart", Restart);
     dispatcher.RegisterMethod("debug.init", Init);
+    dispatcher.RegisterMethod("debug.attach_pid", AttachPid);
     dispatcher.RegisterMethod("debug.stop", Stop);
     
     Logger::Info("Registered debug.* methods");
@@ -188,6 +191,81 @@ json DebugHandler::Init(const json& params) {
     }
     if (!currentDir.empty()) {
         result["current_dir"] = currentDir;
+    }
+
+    return result;
+}
+
+json DebugHandler::AttachPid(const json& params) {
+    if (!params.contains("pid")) {
+        return {
+            {"success", false},
+            {"error", "Missing required parameter 'pid'"}
+        };
+    }
+
+    uint32_t pid = 0;
+    try {
+        if (params["pid"].is_number_unsigned()) {
+            pid = params["pid"].get<uint32_t>();
+        } else if (params["pid"].is_number_integer()) {
+            const int64_t value = params["pid"].get<int64_t>();
+            if (value <= 0) {
+                return {{"success", false}, {"error", "pid must be positive"}};
+            }
+            pid = static_cast<uint32_t>(value);
+        } else if (params["pid"].is_string()) {
+            const std::string text = params["pid"].get<std::string>();
+            const size_t start = text.find_first_not_of(" \t");
+            const size_t end = text.find_last_not_of(" \t");
+            if (start == std::string::npos) {
+                return {{"success", false}, {"error", "pid string is empty"}};
+            }
+            const std::string trimmed = text.substr(start, end - start + 1);
+            const unsigned long parsed = std::strtoul(trimmed.c_str(), nullptr, 10);
+            if (parsed == 0 || parsed > std::numeric_limits<uint32_t>::max()) {
+                return {{"success", false}, {"error", "invalid pid string"}};
+            }
+            pid = static_cast<uint32_t>(parsed);
+        } else {
+            return {{"success", false}, {"error", "pid must be number or string"}};
+        }
+    } catch (const std::exception& e) {
+        return {{"success", false}, {"error", e.what()}};
+    }
+
+    bool useAttachBreak = RequestValidator::GetBoolean(params, "attach_break", false);
+    bool detachFirst = RequestValidator::GetBoolean(params, "detach_first", true);
+    const int64_t timeoutMs = RequestValidator::GetInteger(params, "timeout_ms", 15000);
+
+    auto& controller = DebugController::Instance();
+    const bool success = controller.AttachProcess(
+        pid,
+        static_cast<uint32_t>(timeoutMs > 0 ? timeoutMs : 15000),
+        useAttachBreak,
+        detachFirst
+    );
+
+    json result = {
+        {"success", success},
+        {"requested_pid", pid},
+        {"debugging", controller.IsDebugging()}
+    };
+
+    if (success) {
+        result["state"] = StateToString(controller.GetState());
+        const uint32_t attachedPid = controller.GetDebuggeeProcessId();
+        if (attachedPid != 0) {
+            result["attached_pid"] = attachedPid;
+        }
+        if (controller.IsDebugging()) {
+            try {
+                result["rip"] = StringUtils::FormatAddress(controller.GetInstructionPointer());
+            } catch (...) {
+            }
+        }
+    } else {
+        result["error"] = "attach failed (see x32dbg-mcp.log)";
     }
 
     return result;

--- a/src/handlers/DebugHandler.h
+++ b/src/handlers/DebugHandler.h
@@ -67,6 +67,11 @@ public:
     static json Init(const json& params);
 
     /**
+     * @brief debug.attach_pid - 附加到已运行进程（正确等待暂停，非 script_execute）
+     */
+    static json AttachPid(const json& params);
+
+    /**
      * @brief debug.stop - 停止调试
      */
     static json Stop(const json& params);


### PR DESCRIPTION
## 概述

新增 MCP 工具 **`debug_attach_pid`**：在 x32dbg/x64dbg **已打开、未附加** 时，由自动化（Cursor 等）附加到**已在运行**的进程，无需 `x32dbg.exe -p` 或 GUI「附加」。

同时修复一个容易踩坑的问题：x64dbg 命令行里**数字默认按十六进制解析**。`attach 3580` 实际附加的是 PID `0x3580`，不是十进制 3580。本 PR 统一使用 **`attach .%u`**（`.` 表示十进制，见[官方 Values 文档](https://help.x64dbg.com/en/latest/introduction/Values.html)）。

## 背景问题

- 用 `script_execute` 执行 `attach <pid>` 时，经常**命令还没真正附加完就返回 success**；此时 `debug_get_state: stopped` 也可能只是**未在调试**。
- 直接 `attach <十进制PID>` 在默认解析下会附到错误进程。
- x64dbg **没有** `attachbreak` 这条命令（已移除相关错误用法）。

## 实现要点

- 新 MCP 工具：`debug_attach_pid`（参数：`pid`、`timeout_ms`、`attach_break`、`detach_first`）。
- 在 **x64dbg 命令线程** 执行插件命令：`mcpattach .PID` / `mcpattachbreak .PID` / `mcpdetach`。
- `DebugController::AttachProcessCore` → `DbgCmdExecDirect("attach .%u")`，并等待 `DbgIsDebugging()` 为真。
- 可选：无 vcpkg 时用 CMake **FetchContent** 拉 `nlohmann_json`（`build-x86.ps1` 辅助 x86 构建）。

## 实测环境

- Windows 10，x32dbg 32 位，插件版本 `1.0.8-attach`。
- 空载调试器 → `debug_attach_pid` → `module_get_main`、`breakpoint_set` 正常。
- 日志可见：`AttachProcessCore: attach .<pid> (decimal pid)`。

## 已知限制

- `attach_break: true` 时，目标若一直 **running**，`WaitForPause` 可能超时，但**附加本身通常已成功**；自动化场景建议 `attach_break: false`。
- 失败时的错误码/文案尚未完全打磨。
- 未在本 PR 中单独修复旧版 `script_execute attach` 的“假成功”语义（可另开 issue）。

## 文档

详见本 PR 中的 **`ATTACH.md`**（英文技术说明，含构建与 API 表）。

## 主要改动文件

- `src/business/DebugController.cpp` / `.h`
- `src/handlers/DebugHandler.cpp` / `.h`
- `src/core/MCPToolRegistry.cpp`
- `src/PluginEntry.cpp`
- `ATTACH.md`
- `CMakeLists.txt`、`build-x86.ps1`（可选无 vcpkg 构建路径）
