### PR TITLE
release: v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the x64dbg MCP Server Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-07-13
+
+### Fixed
+- Fixed x32dbg stack walking reading saved EBP and return addresses as 8-byte values, which combined adjacent 32-bit stack entries into invalid 64-bit addresses (#12).
+- Address formatting now uses 8 hexadecimal digits on x32dbg and 16 on x64dbg.
+- ConfigEditor now preserves the `security` section when saving settings.
+
+### Security
+- Added `security.host_allowlist` for explicitly trusted FRP/reverse-proxy hostnames and IP addresses while retaining DNS-rebinding protection (#11).
+- Host matching is case-insensitive, strips ports, and correctly handles bracketed IPv6 hosts.
+- Updated the packaged `config.json` to match secure runtime defaults: memory/register writes and script execution are disabled, and `script.*` is not allowlisted by default.
+
+### Changed
+- Version bumped to 1.0.9 across plugin metadata, protocol responses, configuration, and documentation.
+
 ## [1.0.8] - 2026-05-25
 
 ### Added

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -5,6 +5,21 @@ x64dbg MCP Server Plugin 的所有重要变更都会记录在此文件中。
 格式遵循 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 并采用 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [1.0.9] - 2026-07-13
+
+### 修复
+- 修复 x32dbg 栈回溯将保存的 EBP 和返回地址按 8 字节读取，导致相邻 32 位栈数据被拼接成无效 64 位地址的问题（#12）。
+- x32dbg 地址改为 8 位十六进制格式，x64dbg 继续使用 16 位格式。
+- 配置编辑器保存设置时会保留 `security` 段。
+
+### 安全
+- 新增 `security.host_allowlist`，允许显式信任 FRP/反向代理域名或 IP，同时保留 DNS-rebinding 防护（#11）。
+- Host 匹配忽略大小写、自动移除端口，并正确处理带方括号的 IPv6 Host。
+- 仓库附带的 `config.json` 与安全运行时默认值同步：默认禁用内存/寄存器写入和脚本执行，且默认方法白名单不包含 `script.*`。
+
+### 变更
+- 插件元数据、协议响应、配置及文档中的版本号统一更新至 1.0.9。
+
 ## [1.0.8] - 2026-05-25
 
 ### 新增

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(x64dbg_mcp VERSION 1.0.8 LANGUAGES CXX RC)
+project(x64dbg_mcp VERSION 1.0.9 LANGUAGES CXX RC)
 
 # C++17 标准
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ A Model Context Protocol (MCP) server implementation for x64dbg and x32dbg, enab
 - **Security**: Permission-based access control
 - **Extensible**: Plugin architecture for custom methods, resources, and prompts
 
+## What's New in v1.0.9
+
+- **Remote host allowlist**: `security.host_allowlist` permits explicit FRP/reverse-proxy hostnames or IP addresses without disabling DNS-rebinding protection. Loopback and the configured bind address remain allowed by default.
+- **x32dbg stack trace fix**: x86 saved frame pointers and return addresses are now read at their native 4-byte width, preventing adjacent stack values from being combined into invalid 64-bit addresses.
+- **Architecture-aware addresses**: x32dbg formats addresses as 8 hexadecimal digits; x64dbg continues using 16 digits.
+- **Secure packaged defaults**: the shipped `config.json` now matches runtime defaults, with memory/register writes and script execution disabled.
+
 ## What's New in v1.0.8
 
 - **Security hardening**: Added CORS Origin/Host header validation to prevent CSRF and DNS-rebinding attacks against the HTTP server. All POST endpoints now require a valid `Origin` (if present) to match the configured origin allowlist, and the `Host` header must resolve to a loopback address. Script execution, memory write, and register write are now **disabled by default** (strict opt-in). Removed `Access-Control-Allow-Origin: *` from POST responses.
@@ -227,7 +234,7 @@ Edit `config.json` to customize settings:
 
 ```json
 {
-  "version": "1.0.8",
+  "version": "1.0.9",
   "server": {
     "address": "127.0.0.1",
     "port": 3000
@@ -239,7 +246,8 @@ Edit `config.json` to customize settings:
     "allow_breakpoint_modification": true
   },
   "security": {
-    "origin_allowlist": []
+    "origin_allowlist": [],
+    "host_allowlist": []
   },
   "logging": {
     "enabled": true,

--- a/config.json
+++ b/config.json
@@ -1,13 +1,13 @@
 {
-  "version": "1.0.7",
+  "version": "1.0.9",
   "server": {
     "address": "127.0.0.1",
     "port": 3000
   },
   "permissions": {
-    "allow_memory_write": true,
-    "allow_register_write": true,
-    "allow_script_execution": true,
+    "allow_memory_write": false,
+    "allow_register_write": false,
+    "allow_script_execution": false,
     "allow_breakpoint_modification": true,
     "allowed_methods": [
       "debug.*",
@@ -21,7 +21,6 @@
       "thread.*",
       "stack.*",
       "comment.*",
-      "script.*",
       "context.*",
       "dump.*",
       "eval.*",
@@ -38,6 +37,10 @@
     "file": "x64dbg_mcp.log",
     "max_file_size_mb": 10,
     "console_output": true
+  },
+  "security": {
+    "origin_allowlist": [],
+    "host_allowlist": []
   },
   "timeout": {
     "request_timeout_ms": 30000,

--- a/docs/QUICKSTART_CN.md
+++ b/docs/QUICKSTART_CN.md
@@ -229,7 +229,7 @@ instructions = response["result"]["instructions"]
 
 ```json
 {
-  "version": "1.0.8",
+  "version": "1.0.9",
   "server": {
     "address": "127.0.0.1",
     "port": 3000
@@ -241,7 +241,8 @@ instructions = response["result"]["instructions"]
     "allow_breakpoint_modification": true
   },
   "security": {
-    "origin_allowlist": []
+    "origin_allowlist": [],
+    "host_allowlist": []
   },
   "logging": {
     "enabled": true,

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -42,6 +42,13 @@
 - **安全性**：基于权限的访问控制
 - **可扩展性**：支持自定义方法、资源与提示的插件架构
 
+## v1.0.9 更新内容
+
+- **远程 Host 白名单**：新增 `security.host_allowlist`，可显式允许 FRP/反向代理使用的域名或 IP，同时保留 DNS-rebinding 防护。
+- **x32dbg 栈回溯修复**：x86 保存的帧指针和返回地址改为按原生 4 字节读取，避免相邻栈数据被拼接成无效 64 位地址。
+- **架构相关地址格式**：x32dbg 使用 8 位十六进制地址，x64dbg 继续使用 16 位地址。
+- **安全默认配置同步**：附带的 `config.json` 默认关闭内存/寄存器写入和脚本执行。
+
 ## v1.0.8 更新内容
 
 - **安全加固**：新增 CORS Origin/Host 头校验，防止浏览器发起的 CSRF 和 DNS-rebinding 攻击。所有 POST 端点在校验 `Origin`（如存在）时仅允许已配置的白名单来源，同时 `Host` 头必须指向本机回环地址。脚本执行、内存写入、寄存器写入现已**默认关闭**（显式 opt-in）。移除 POST 响应中的 `Access-Control-Allow-Origin: *`。
@@ -216,7 +223,7 @@ copy config.json <x64dbg-path>\x32\plugins\x32dbg-mcp\
 
 ```json
 {
-  "version": "1.0.8",
+  "version": "1.0.9",
   "server": {
     "address": "127.0.0.1",
     "port": 3000
@@ -228,7 +235,8 @@ copy config.json <x64dbg-path>\x32\plugins\x32dbg-mcp\
     "allow_breakpoint_modification": true
   },
   "security": {
-    "origin_allowlist": []
+    "origin_allowlist": [],
+    "host_allowlist": []
   },
   "logging": {
     "enabled": true,

--- a/src/PluginEntry.cpp
+++ b/src/PluginEntry.cpp
@@ -34,7 +34,7 @@
 #include <fstream>
 
 // 鎻掍欢鐗堟湰淇℃�?
-#define PLUGIN_VERSION "1.0.8"
+#define PLUGIN_VERSION "1.0.9"
 
 // 鍙�?CMake 瑕嗙洊锛歅LUGIN_DISPLAY_NAME, PLUGIN_DIR_NAME
 #ifndef PLUGIN_DISPLAY_NAME
@@ -560,7 +560,7 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct) {
                 std::ofstream configFile(configPath);
                 if (configFile.is_open()) {
                     configFile << R"({
-  "version": "1.0.8",
+  "version": "1.0.9",
   "server": {
     "address": "127.0.0.1",
     "port": 3000
@@ -593,7 +593,8 @@ extern "C" __declspec(dllexport) bool pluginit(PLUG_INITSTRUCT* initStruct) {
     ]
   },
   "security": {
-    "origin_allowlist": []
+    "origin_allowlist": [],
+    "host_allowlist": []
   },
     "logging": {
         "enabled": true,

--- a/src/business/StackManager.cpp
+++ b/src/business/StackManager.cpp
@@ -63,16 +63,17 @@ std::vector<StackFrame> StackManager::GetStackTraceManual(size_t maxDepth) {
     
     // 根据架构获取正确的寄存器
 #ifdef XDBG_ARCH_X64
+    using StackPointer = uint64_t;
     uint64_t rsp = regMgr.GetRegister("rsp");
     uint64_t rbp = regMgr.GetRegister("rbp");
     uint64_t rip = regMgr.GetRegister("rip");
-    const size_t ptrSize = 8;
 #else
+    using StackPointer = uint32_t;
     uint64_t rsp = regMgr.GetRegister("esp");
     uint64_t rbp = regMgr.GetRegister("ebp");
     uint64_t rip = regMgr.GetRegister("eip");
-    const size_t ptrSize = 4;
 #endif
+    const size_t ptrSize = sizeof(StackPointer);
     
     LOG_DEBUG("Stack trace starting from IP={:016X}, SP={:016X}, BP={:016X}", rip, rsp, rbp);
     
@@ -100,20 +101,23 @@ std::vector<StackFrame> StackManager::GetStackTraceManual(size_t maxDepth) {
         }
         
         // 读取返回地址（RBP 通常指向保存的上一层 RBP，返回地址在 RBP+8）
-        uint64_t returnAddress = 0;
-        uint64_t savedRBP = 0;
-        
-        // 读取保存的 RBP
-        if (!Script::Memory::Read(currentRBP, &savedRBP, sizeof(savedRBP), nullptr)) {
+        StackPointer returnPointer = 0;
+        StackPointer savedPointer = 0;
+
+        // Read the saved frame pointer.
+        if (!Script::Memory::Read(currentRBP, &savedPointer, sizeof(savedPointer), nullptr)) {
             LOG_DEBUG("Failed to read saved RBP at {:016X}", currentRBP);
             break;
         }
-        
-        // 读取返回地址（在调用约定中，返回地址在 BP + 指针大小）
-        if (!Script::Memory::Read(currentRBP + ptrSize, &returnAddress, sizeof(returnAddress), nullptr)) {
+        const uint64_t savedRBP = static_cast<uint64_t>(savedPointer);
+
+        // Read the return address at the native pointer offset.
+        if (!Script::Memory::Read(currentRBP + ptrSize, &returnPointer,
+                                  sizeof(returnPointer), nullptr)) {
             LOG_DEBUG("Failed to read return address at {:016X}", currentRBP + ptrSize);
             break;
         }
+        const uint64_t returnAddress = static_cast<uint64_t>(returnPointer);
         
         // 验证返回地址
         if (returnAddress == 0 || returnAddress < 0x10000) {

--- a/src/communication/MCPHttpServer.cpp
+++ b/src/communication/MCPHttpServer.cpp
@@ -863,7 +863,7 @@ std::string MCPHttpServer::HandleMCPMethod(const std::string& method, const std:
         return "{\"jsonrpc\":\"2.0\",\"id\":" + requestId +
                ",\"result\":{\"protocolVersion\":\"2024-11-05\","
                "\"capabilities\":{\"tools\":{},\"resources\":{},\"prompts\":{}},"
-               "\"serverInfo\":{\"name\":\"x64dbg-mcp\",\"version\":\"1.0.8\"}}}";
+               "\"serverInfo\":{\"name\":\"x64dbg-mcp\",\"version\":\"1.0.9\"}}}";
     }
     else if (method == "notifications/initialized") {
         // 杩欐槸瀹㈡埛绔彂鐨勯€氱煡锛屼笉闇€瑕佸搷搴?
@@ -1228,16 +1228,36 @@ bool MCPHttpServer::ValidateCrossOriginAndHost(const std::string& origin, const 
     }
 
     // Host header validation for DNS-rebinding defense.
-    // The Host must match the configured bind address or a well-known loopback address.
+    // The Host must match the configured bind address, a loopback address, or an explicit allowlist entry.
     if (!host.empty()) {
         std::string hostOnly = host;
-        const size_t colonPos = hostOnly.find(':');
-        if (colonPos != std::string::npos) {
-            hostOnly = hostOnly.substr(0, colonPos);
+        if (!hostOnly.empty() && hostOnly.front() == '[') {
+            const size_t closingBracket = hostOnly.find(']');
+            if (closingBracket != std::string::npos) {
+                hostOnly = hostOnly.substr(1, closingBracket - 1);
+            }
+        } else {
+            const size_t colonPos = hostOnly.find(':');
+            if (colonPos != std::string::npos) {
+                hostOnly = hostOnly.substr(0, colonPos);
+            }
         }
+        hostOnly = ToLowerCopy(hostOnly);
 
-        const bool valid = (hostOnly == "127.0.0.1" || hostOnly == "localhost" ||
-                            hostOnly == "::1" || hostOnly == m_host);
+        bool valid = (hostOnly == "127.0.0.1" || hostOnly == "localhost" ||
+                      hostOnly == "::1" || hostOnly == ToLowerCopy(m_host));
+        if (!valid) {
+            const json allowlist = config.GetHostAllowlist();
+            if (allowlist.is_array()) {
+                for (const auto& entry : allowlist) {
+                    if (entry.is_string() &&
+                        ToLowerCopy(entry.get<std::string>()) == hostOnly) {
+                        valid = true;
+                        break;
+                    }
+                }
+            }
+        }
         if (!valid) {
             Logger::Warning("[Security] Rejected POST with unexpected Host: {}", host);
             return false;

--- a/src/communication/MCPHttpServer.h
+++ b/src/communication/MCPHttpServer.h
@@ -92,7 +92,7 @@ private:
 
     // Validate Origin + Host headers to prevent CSRF/DNS-rebinding attacks
     // - If Origin is present, it must be in the configured allowlist (empty by default).
-    // - If Host is present, it must match 127.0.0.1, localhost, or the bind address.
+    // If Host is present, it must match a loopback address, the bind address, or the configured allowlist.
     bool ValidateCrossOriginAndHost(const std::string& origin, const std::string& host);
     
     // 发送 HTTP 响应

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -14,7 +14,7 @@ ConfigManager& ConfigManager::Instance() {
 json ConfigManager::CreateDefaultConfig() const {
     json config;
     
-    config["version"] = "1.0.8";
+    config["version"] = "1.0.9";
     
     // Server configuration
     config["server"]["address"] = "127.0.0.1";
@@ -42,6 +42,7 @@ json ConfigManager::CreateDefaultConfig() const {
     
     // Security
     config["security"]["origin_allowlist"] = json::array();
+    config["security"]["host_allowlist"] = json::array();
 
     // Timeout
     config["timeout"]["request_timeout_ms"] = 30000;
@@ -228,6 +229,10 @@ bool ConfigManager::IsScriptExecutionAllowed() const {
 
 json ConfigManager::GetOriginAllowlist() const {
     return Get<json>("security.origin_allowlist", json::array());
+}
+
+json ConfigManager::GetHostAllowlist() const {
+    return Get<json>("security.host_allowlist", json::array());
 }
 
 std::string ConfigManager::GetLogLevel() const {

--- a/src/core/ConfigManager.h
+++ b/src/core/ConfigManager.h
@@ -57,6 +57,7 @@ public:
     bool IsScriptExecutionAllowed() const;
     
     json GetOriginAllowlist() const;
+    json GetHostAllowlist() const;
     std::string GetLogLevel() const;
     std::string GetLogFile() const;
     bool IsLoggingEnabled() const;

--- a/src/core/MethodDispatcher.cpp
+++ b/src/core/MethodDispatcher.cpp
@@ -78,7 +78,7 @@ void MethodDispatcher::RegisterDefaultMethods() {
     RegisterMethod("system.info", [](const json& params) -> json {
         return {
             {"name", "x64dbg MCP Server"},
-            {"version", "1.0.8"},
+            {"version", "1.0.9"},
             {"protocol_version", "2.0"},
             {"capabilities", {
                 {"debug", true},

--- a/src/ui/ConfigEditor.cpp
+++ b/src/ui/ConfigEditor.cpp
@@ -291,9 +291,13 @@ json ConfigEditor::GetConfigFromControls(HWND hwndDlg) {
     // Keep menu-managed toggle persisted even though it has no dialog control.
     config["features"]["auto_start_mcp_on_plugin_load"] =
         s_config.value("features", json::object()).value("auto_start_mcp_on_plugin_load", false);
-    
+    config["security"] = s_config.value("security", json::object({
+        {"origin_allowlist", json::array()},
+        {"host_allowlist", json::array()}
+    }));
+
     // 保留version字段
-    config["version"] = s_config.value("version", "1.0.8");
+    config["version"] = s_config.value("version", "1.0.9");
     
     return config;
 }

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -164,7 +164,12 @@ inline std::string FormatAddress(uint64_t address, bool prefix = true) {
     if (prefix) {
         oss << "0x";
     }
-    oss << std::hex << std::uppercase << std::setfill('0') << std::setw(16) << address;
+#ifdef XDBG_ARCH_X64
+    constexpr int addressWidth = 16;
+#else
+    constexpr int addressWidth = 8;
+#endif
+    oss << std::hex << std::uppercase << std::setfill('0') << std::setw(addressWidth) << address;
     return oss.str();
 }
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "x64dbg-mcp",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "builtin-baseline": "8097e8d34cd45f7a5b1f5d90c92be2198e3d712f",
   "dependencies": [
     "nlohmann-json"


### PR DESCRIPTION
## Summary
- Fix x32dbg stack trace pointer-width handling (#12)
- Add explicit Host allowlist support for FRP and reverse proxies while retaining DNS-rebinding protection (#11)
- Synchronize secure defaults and version metadata to v1.0.9

## Verification
- `python -m json.tool config.json`
- `git diff --check`
- `./build.bat --clean` (x64 and x86 Release)