### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #15)

### DIFF
--- a/skills/commands/analyze-crash.md
+++ b/skills/commands/analyze-crash.md
@@ -1,6 +1,6 @@
 ---
 description: Systematic crash root cause analysis with classification
-argument-hint: [crash-address]
+argument-hint: "[crash-address]"
 ---
 
 You are a crash analysis expert connected to x64dbg via MCP. Perform a systematic crash analysis.

--- a/skills/commands/api-monitor.md
+++ b/skills/commands/api-monitor.md
@@ -1,6 +1,6 @@
 ---
 description: Set up logging breakpoints on Windows API categories
-argument-hint: [category]
+argument-hint: "[category]"
 ---
 
 You are an API monitoring specialist connected to x64dbg via MCP. Set up monitoring for API calls.

--- a/skills/commands/debug-session.md
+++ b/skills/commands/debug-session.md
@@ -1,6 +1,6 @@
 ---
 description: Initialize a debugging session with full environment assessment
-argument-hint: [issue-description]
+argument-hint: "[issue-description]"
 ---
 
 You are a reverse engineering assistant connected to x64dbg via MCP. The user is starting a new debugging session.

--- a/skills/commands/dump-memory.md
+++ b/skills/commands/dump-memory.md
@@ -1,6 +1,6 @@
 ---
 description: Memory region analysis and dumping
-argument-hint: [address-or-description]
+argument-hint: "[address-or-description]"
 ---
 
 You are a memory forensics specialist connected to x64dbg via MCP. Dump and analyze memory regions.

--- a/skills/commands/find-vuln.md
+++ b/skills/commands/find-vuln.md
@@ -1,6 +1,6 @@
 ---
 description: Security vulnerability scanning and dangerous API detection
-argument-hint: [vulnerability-type]
+argument-hint: "[vulnerability-type]"
 ---
 
 You are a vulnerability research specialist connected to x64dbg via MCP. Identify potential security vulnerabilities.

--- a/skills/commands/hunt-strings.md
+++ b/skills/commands/hunt-strings.md
@@ -1,6 +1,6 @@
 ---
 description: String searching with cross-reference analysis
-argument-hint: [search-pattern]
+argument-hint: "[search-pattern]"
 ---
 
 You are a string analysis specialist connected to x64dbg via MCP. Search for interesting strings in the binary.

--- a/skills/commands/unpack.md
+++ b/skills/commands/unpack.md
@@ -1,6 +1,6 @@
 ---
 description: Manual unpacking workflow for packed/protected executables
-argument-hint: [packer-hint]
+argument-hint: "[packer-hint]"
 ---
 
 You are a binary unpacking specialist connected to x64dbg via MCP. Help unpack a packed or protected executable through manual analysis.


### PR DESCRIPTION
Closes #15.

## Summary

Purely mechanical single-character transform to 6 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (6)

- `skills/commands/debug-session.md`
- `skills/commands/api-monitor.md`
- `skills/commands/hunt-strings.md`
- `skills/commands/find-vuln.md`
- `skills/commands/unpack.md`
- `skills/commands/analyze-crash.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
