### PR TITLE
fix(attach): drop decimal prefix from mcpattach plugin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the x64dbg MCP Server Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed `debug_attach_pid` timing out on x64dbg: the `mcpattach` plugin command was formatted with a leading `.` (e.g. `mcpattach .6520`) which the x64dbg command parser passes verbatim to `argv[1]`. `ParsePidArg` uses `strtoul` with base 10, so `.` caused the parse to fail silently — `AttachProcessCore` was never called, and `WaitForDebugging` timed out after 15 seconds.
+- `ParsePidArg` now tolerates leading `.` (x64dbg decimal prefix) and `0x`/`0X` (hex prefix) for defense in depth.
+- Error message `"attach failed (see x32dbg-mcp.log)"` now correctly uses `PLUGIN_DIR_NAME` so it points to `x64dbg-mcp.log` on 64-bit builds.
+
 ## [1.0.9] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -5,6 +5,13 @@ x64dbg MCP Server Plugin 的所有重要变更都会记录在此文件中。
 格式遵循 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 并采用 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [Unreleased]
+
+### 修复
+- 修复 `debug_attach_pid` 在 x64dbg 上超时的问题：`mcpattach` 插件命令格式中带前导 `.`（如 `mcpattach .6520`），x64dbg 命令解析器原样传入 `argv[1]`。`ParsePidArg` 使用 `strtoul` 以十进制解析，`.` 导致解析静默失败 — `AttachProcessCore` 从未被调用，`WaitForDebugging` 15 秒后超时。
+- `ParsePidArg` 现在容错前导 `.`（x64dbg 十进制前缀）和 `0x`/`0X`（十六进制前缀）作为深度防御。
+- 错误信息 `"attach failed (see x32dbg-mcp.log)"` 现在使用 `PLUGIN_DIR_NAME` 动态拼接，x64 构建下指向正确的 `x64dbg-mcp.log`。
+
 ## [1.0.9] - 2026-07-13
 
 ### 修复

--- a/src/PluginEntry.cpp
+++ b/src/PluginEntry.cpp
@@ -434,10 +434,20 @@ static uint32_t ParsePidArg(const char* text) {
     if (text == nullptr || *text == '\0') {
         return 0;
     }
+    // skip leading '.' (x64dbg decimal prefix) or "0x" (hex prefix)
+    const char* p = text;
+    if (*p == '.') {
+        ++p;
+    } else if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        p += 2;
+    }
+    if (*p == '\0') {
+        return 0;
+    }
     char* end = nullptr;
     errno = 0;
-    const unsigned long value = std::strtoul(text, &end, 10);
-    if (errno == ERANGE || end == text || *end != '\0' || value == 0) {
+    const unsigned long value = std::strtoul(p, &end, 10);
+    if (errno == ERANGE || end == p || *end != '\0' || value == 0) {
         return 0;
     }
     return static_cast<uint32_t>(value);

--- a/src/business/DebugController.cpp
+++ b/src/business/DebugController.cpp
@@ -444,7 +444,7 @@ bool DebugController::AttachProcess(uint32_t pid,
     }
 
     char pluginCmd[32] = {};
-    sprintf_s(pluginCmd, "mcpattach .%u", pid);
+    sprintf_s(pluginCmd, "mcpattach %u", pid);
     (void)useAttachBreak;
     Logger::Info("AttachProcess: queue {}", pluginCmd);
     if (!ExecuteCommand(pluginCmd)) {

--- a/src/handlers/DebugHandler.cpp
+++ b/src/handlers/DebugHandler.cpp
@@ -280,7 +280,7 @@ json DebugHandler::AttachPid(const json& params) {
             }
         }
     } else {
-        result["error"] = "attach failed (see x32dbg-mcp.log)";
+        result["error"] = std::string("attach failed (see ") + PLUGIN_DIR_NAME + ".log)";
     }
 
     return result;


### PR DESCRIPTION
## 问题

`debug_attach_pid` 在 x64dbg 上执行时始终 15 秒超时，返回 `attach failed (see x32dbg-mcp.log)`。

## 根因

`DebugController::AttachProcess` 构造的插件命令为 `mcpattach .%u`（如 `mcpattach .6520`），x64dbg 命令解析器将 `.6520` 原样传入 `argv[1]`（不进行表达式求值）。`ParsePidArg` 使用 `strtoul` 以十进制解析时，前导 `.` 导致 subject sequence 为空，返回 0，`CmdMcpAttach` 静默返回 false，`AttachProcessCore` 从未被调用，`DbgIsDebugging()` 恒为 false，`WaitForDebugging` 15 秒后超时。

## 修复

1. **DebugController.cpp** — `sprintf_s(pluginCmd, "mcpattach .%u", pid)` 改为 `"mcpattach %u"`。插件命令参数不应该加前导 `.`。
2. **PluginEntry.cpp** — `ParsePidArg` 增加前导 `.`/`0x` 容错。
3. **DebugHandler.cpp** — 硬编码的 `"x32dbg-mcp.log"` 改为 `PLUGIN_DIR_NAME + ".log"`。

## 验证

修复后调用链：`mcpattach 6520` → `ParsePidArg("6520")` → strtoul 返回 6520 → `AttachProcessCore` 被调用 → `sprintf_s(command, "attach .%u", pid)` 生成 `attach .6520` → 正常附加。
