### PR TITLE
feat(http): add CORS OPTIONS preflight handler and response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added CORS support for browser-based MCP clients with allowlisted origins:
+  - `OPTIONS` preflight requests are supported on all MCP HTTP endpoints.
+  - Standard and streaming responses reflect the validated request Origin.
+  - SSE endpoints preserve the origin allowlist instead of using wildcard CORS.
+
 ### Fixed
 - Fixed `debug_attach_pid` timing out on x64dbg: the `mcpattach` plugin command was formatted with a leading `.` (e.g. `mcpattach .6520`) which the x64dbg command parser passes verbatim to `argv[1]`. `ParsePidArg` uses `strtoul` with base 10, so `.` caused the parse to fail silently — `AttachProcessCore` was never called, and `WaitForDebugging` timed out after 15 seconds.
 - `ParsePidArg` now tolerates leading `.` (x64dbg decimal prefix) and `0x`/`0X` (hex prefix) for defense in depth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the x64dbg MCP Server Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- CORS support for browser-based MCP clients (e.g. MCP Inspector Web UI):
+  - `OPTIONS` preflight handler returns proper CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age`).
+  - All responses now include `Access-Control-Allow-Origin` when the request has a valid `Origin` header.
+  - SSE and Streamable HTTP stream responses include `Access-Control-Allow-Origin: *` (Origin is validated before routing).
+
 ## [1.0.9] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -7,6 +7,12 @@ x64dbg MCP Server Plugin 的所有重要变更都会记录在此文件中。
 
 ## [Unreleased]
 
+### 新增
+- 为浏览器 MCP 客户端新增基于来源白名单的 CORS 支持：
+  - 所有 MCP HTTP 端点均支持 `OPTIONS` 预检请求。
+  - 普通响应和流式响应精确回显已验证的请求 Origin。
+  - SSE 端点继续遵循来源白名单，不使用通配 CORS。
+
 ### 修复
 - 修复 `debug_attach_pid` 在 x64dbg 上超时的问题：`mcpattach` 插件命令格式中带前导 `.`（如 `mcpattach .6520`），x64dbg 命令解析器原样传入 `argv[1]`。`ParsePidArg` 使用 `strtoul` 以十进制解析，`.` 导致解析静默失败 — `AttachProcessCore` 从未被调用，`WaitForDebugging` 15 秒后超时。
 - `ParsePidArg` 现在容错前导 `.`（x64dbg 十进制前缀）和 `0x`/`0X`（十六进制前缀）作为深度防御。

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -5,6 +5,14 @@ x64dbg MCP Server Plugin 的所有重要变更都会记录在此文件中。
 格式遵循 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 并采用 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)。
 
+## [Unreleased]
+
+### 新增
+- 浏览器端 MCP 客户端（如 MCP Inspector Web UI）的 CORS 支持：
+  - `OPTIONS` 预检处理器返回正确的 CORS 头（`Access-Control-Allow-Origin`、`Access-Control-Allow-Methods`、`Access-Control-Allow-Headers`、`Access-Control-Max-Age`）。
+  - 所有响应在请求携带有效 `Origin` 头时包含 `Access-Control-Allow-Origin`。
+  - SSE 和 Streamable HTTP 流响应包含 `Access-Control-Allow-Origin: *`（Origin 已在路由前校验）。
+
 ## [1.0.9] - 2026-07-13
 
 ### 修复

--- a/src/communication/MCPHttpServer.cpp
+++ b/src/communication/MCPHttpServer.cpp
@@ -534,17 +534,8 @@ void MCPHttpServer::HandleClient(SOCKET clientSocket) {
         return;
     }
 
-    std::string method;
-    std::string path;
-    std::string body;
-    const bool isPersistentStream = ParseHttpRequest(request, method, path, body) &&
-        method == "GET" && (path == "/sse" || path == "/mcp" || path == "/mcp/");
-
     HandleHttpRequest(clientSocket, request);
-
-    if (!isPersistentStream) {
-        closesocket(clientSocket);
-    }
+    closesocket(clientSocket);
 }
 
 void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& request) {
@@ -558,6 +549,13 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     Logger::Debug("HTTP Request: " + method + " " + path);
 
     const std::string origin = GetHttpHeader(request, "Origin");
+    const std::string host = GetHttpHeader(request, "Host");
+
+    // Validate untrusted headers before reflecting Origin in any response.
+    if (!ValidateCrossOriginAndHost(origin, host)) {
+        SendHttpResponse(clientSocket, 403, "{\"error\":\"Forbidden\"}");
+        return;
+    }
 
     // Rate limiting: reject excessive requests (DoS protection).
     if (!g_rateLimiter.Allow()) {
@@ -565,20 +563,10 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
         return;
     }
 
-    // CSRF / DNS-rebinding defense: validate Origin and Host on all
-    // mutable (POST) and streaming (GET /sse, GET /mcp) paths.
-    if (method == "POST" || method == "OPTIONS" || path == "/sse" ||
-        path == "/mcp" || path == "/mcp/") {
-        const std::string host = GetHttpHeader(request, "Host");
-        if (!ValidateCrossOriginAndHost(origin, host)) {
-            SendHttpResponse(clientSocket, 403, "{\"error\":\"Forbidden\"}", "application/json", origin);
-            return;
-        }
-    }
-
     // CORS preflight for browser-based clients (e.g. MCP Inspector Web UI).
     if (method == "OPTIONS" && (path == "/mcp" || path == "/mcp/" ||
-        path == "/sse" || path == "/message" || path == "/")) {
+        path == "/sse" || path == "/message" || path == "/messages" ||
+        path == "/rpc" || path == "/rpc/" || path == "/")) {
         std::ostringstream resp;
         resp << "HTTP/1.1 204 No Content\r\n"
              << "Content-Length: 0\r\n";
@@ -592,12 +580,11 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
              << "Access-Control-Max-Age: 86400\r\n"
              << "Connection: close\r\n\r\n";
         SendAll(clientSocket, resp.str());
-        closesocket(clientSocket);
         return;
     }
 
     if (method == "GET" && path == "/sse") {
-        HandleSSE(clientSocket);
+        HandleSSE(clientSocket, origin);
     }
     else if (method == "POST" && (path == "/mcp" || path == "/mcp/")) {
         // Streamable HTTP transport (MCP 2025-03-26): single MCP endpoint.
@@ -605,7 +592,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     }
     else if (method == "GET" && (path == "/mcp" || path == "/mcp/")) {
         // Streamable HTTP GET stream for server-initiated notifications.
-        HandleStreamableHttpStream(clientSocket);
+        HandleStreamableHttpStream(clientSocket, origin);
     }
     else if (method == "DELETE" && (path == "/mcp" || path == "/mcp/")) {
         // Stateless server: clients cannot terminate sessions explicitly.
@@ -616,7 +603,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
              (path == "/message" || path == "/" || path == "/messages" ||
               path == "/rpc" || path == "/rpc/")) {
         // 鏀寔澶氱 POST 璺緞锛?, /message, /messages
-        HandlePostMessage(clientSocket, body);
+        HandlePostMessage(clientSocket, body, origin);
     }
     else if (method == "GET" && path == "/") {
         // 鍋ュ悍妫€鏌?
@@ -638,19 +625,21 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     }
 }
 
-void MCPHttpServer::HandleSSE(SOCKET clientSocket) {
+void MCPHttpServer::HandleSSE(SOCKET clientSocket, const std::string& origin) {
     // 鍙戦€?SSE 鍝嶅簲澶?
-    std::string headers = 
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Type: text/event-stream; charset=utf-8\r\n"
-        "Cache-Control: no-cache\r\n"
-        "Access-Control-Allow-Origin: *\r\n"
-        "Connection: keep-alive\r\n"
-        "\r\n";
+    std::ostringstream headerStream;
+    headerStream << "HTTP/1.1 200 OK\r\n"
+                 << "Content-Type: text/event-stream; charset=utf-8\r\n"
+                 << "Cache-Control: no-cache\r\n";
+    if (!origin.empty()) {
+        headerStream << "Access-Control-Allow-Origin: " << origin << "\r\n"
+                     << "Vary: Origin\r\n";
+    }
+    headerStream << "Connection: keep-alive\r\n\r\n";
+    const std::string headers = headerStream.str();
 
     if (!SendAll(clientSocket, headers)) {
         Logger::Error("Failed to send SSE headers");
-        closesocket(clientSocket);
         return;
     }
 
@@ -663,7 +652,6 @@ void MCPHttpServer::HandleSSE(SOCKET clientSocket) {
         std::lock_guard<std::mutex> lock(m_sseSendMutex);
         if (!SendAll(clientSocket, endpointEvent)) {
             Logger::Error("Failed to send SSE endpoint event");
-            closesocket(clientSocket);
             return;
         }
     }
@@ -781,17 +769,19 @@ void MCPHttpServer::HandleSSE(SOCKET clientSocket) {
         std::lock_guard<std::mutex> lock(m_sseClientSocketsMutex);
         m_sseClientSockets.erase(clientSocket);
     }
-    closesocket(clientSocket);
 }
 
-void MCPHttpServer::HandlePostMessage(SOCKET clientSocket, const std::string& body) {
+void MCPHttpServer::HandlePostMessage(SOCKET clientSocket, const std::string& body,
+                                      const std::string& origin) {
     Logger::Debug("POST body received: " + body);
 
     try {
         [[maybe_unused]] const auto parsed = json::parse(body);
     } catch (const json::exception&) {
         Logger::Error("Failed to parse JSON body");
-        SendHttpResponse(clientSocket, 400, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}");
+        SendHttpResponse(clientSocket, 400,
+                         "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}",
+                         "application/json", origin);
         return;
     }
 
@@ -799,7 +789,9 @@ void MCPHttpServer::HandlePostMessage(SOCKET clientSocket, const std::string& bo
     bool hasRequestId = false;
     if (!ParseJsonRpcRequest(body, method, requestId, hasRequestId)) {
         Logger::Error("Invalid JSON-RPC request");
-        SendHttpResponse(clientSocket, 400, "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"}}");
+        SendHttpResponse(clientSocket, 400,
+                         "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"}}",
+                         "application/json", origin);
         return;
     }
 
@@ -817,19 +809,19 @@ void MCPHttpServer::HandlePostMessage(SOCKET clientSocket, const std::string& bo
 
     // Notification (no id) or methods with no payload: 202 either way.
     if (!hasRequestId || response.empty()) {
-        SendHttpResponse(clientSocket, 202, "");
+        SendHttpResponse(clientSocket, 202, "", "application/json", origin);
         return;
     }
 
     if (hasSseClient) {
         // MCP SSE contract: ack the POST with 202, push response via SSE.
-        SendHttpResponse(clientSocket, 202, "");
+        SendHttpResponse(clientSocket, 202, "", "application/json", origin);
         BroadcastSSEEvent("message", response);
         Logger::Debug("Response dispatched via SSE: " + response);
     } else {
         // Fallback for plain HTTP clients (no SSE attached): reply inline.
         Logger::Debug("Inline reply (no SSE client): " + response);
-        SendHttpResponse(clientSocket, 200, response);
+        SendHttpResponse(clientSocket, 200, response, "application/json", origin);
     }
 }
 
@@ -1477,18 +1469,21 @@ void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::str
     SendHttpResponse(clientSocket, 200, response, "application/json", origin);
 }
 
-void MCPHttpServer::HandleStreamableHttpStream(SOCKET clientSocket) {
-    const std::string headers =
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Type: text/event-stream; charset=utf-8\r\n"
-        "Cache-Control: no-cache\r\n"
-        "Access-Control-Allow-Origin: *\r\n"
-        "Connection: keep-alive\r\n"
-        "\r\n";
+void MCPHttpServer::HandleStreamableHttpStream(SOCKET clientSocket,
+                                               const std::string& origin) {
+    std::ostringstream headerStream;
+    headerStream << "HTTP/1.1 200 OK\r\n"
+                 << "Content-Type: text/event-stream; charset=utf-8\r\n"
+                 << "Cache-Control: no-cache\r\n";
+    if (!origin.empty()) {
+        headerStream << "Access-Control-Allow-Origin: " << origin << "\r\n"
+                     << "Vary: Origin\r\n";
+    }
+    headerStream << "Connection: keep-alive\r\n\r\n";
+    const std::string headers = headerStream.str();
 
     if (!SendAll(clientSocket, headers)) {
         Logger::Error("[Streamable HTTP] Failed to send stream headers");
-        closesocket(clientSocket);
         return;
     }
 
@@ -1538,7 +1533,6 @@ void MCPHttpServer::HandleStreamableHttpStream(SOCKET clientSocket) {
         std::lock_guard<std::mutex> lock(m_sseClientSocketsMutex);
         m_sseClientSockets.erase(clientSocket);
     }
-    closesocket(clientSocket);
 }
 
 } // namespace MCP

--- a/src/communication/MCPHttpServer.cpp
+++ b/src/communication/MCPHttpServer.cpp
@@ -557,22 +557,43 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
 
     Logger::Debug("HTTP Request: " + method + " " + path);
 
+    const std::string origin = GetHttpHeader(request, "Origin");
+
     // Rate limiting: reject excessive requests (DoS protection).
     if (!g_rateLimiter.Allow()) {
-        SendHttpResponse(clientSocket, 429, "{\"error\":\"Too Many Requests\"}");
+        SendHttpResponse(clientSocket, 429, "{\"error\":\"Too Many Requests\"}", "application/json", origin);
         return;
     }
 
     // CSRF / DNS-rebinding defense: validate Origin and Host on all
     // mutable (POST) and streaming (GET /sse, GET /mcp) paths.
-    if (method == "POST" || path == "/sse" ||
+    if (method == "POST" || method == "OPTIONS" || path == "/sse" ||
         path == "/mcp" || path == "/mcp/") {
-        const std::string origin = GetHttpHeader(request, "Origin");
         const std::string host = GetHttpHeader(request, "Host");
         if (!ValidateCrossOriginAndHost(origin, host)) {
-            SendHttpResponse(clientSocket, 403, "{\"error\":\"Forbidden\"}");
+            SendHttpResponse(clientSocket, 403, "{\"error\":\"Forbidden\"}", "application/json", origin);
             return;
         }
+    }
+
+    // CORS preflight for browser-based clients (e.g. MCP Inspector Web UI).
+    if (method == "OPTIONS" && (path == "/mcp" || path == "/mcp/" ||
+        path == "/sse" || path == "/message" || path == "/")) {
+        std::ostringstream resp;
+        resp << "HTTP/1.1 204 No Content\r\n"
+             << "Content-Length: 0\r\n";
+        if (!origin.empty()) {
+            resp << "Access-Control-Allow-Origin: " << origin << "\r\n"
+                 << "Vary: Origin\r\n";
+        }
+        resp << "Access-Control-Allow-Methods: POST, GET, DELETE, OPTIONS\r\n"
+             << "Access-Control-Allow-Headers: Content-Type, Accept, Authorization, "
+                "Mcp-Protocol-Version, Mcp-Session-Id, Last-Event-ID\r\n"
+             << "Access-Control-Max-Age: 86400\r\n"
+             << "Connection: close\r\n\r\n";
+        SendAll(clientSocket, resp.str());
+        closesocket(clientSocket);
+        return;
     }
 
     if (method == "GET" && path == "/sse") {
@@ -580,7 +601,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     }
     else if (method == "POST" && (path == "/mcp" || path == "/mcp/")) {
         // Streamable HTTP transport (MCP 2025-03-26): single MCP endpoint.
-        HandleStreamableHttpPost(clientSocket, body);
+        HandleStreamableHttpPost(clientSocket, body, origin);
     }
     else if (method == "GET" && (path == "/mcp" || path == "/mcp/")) {
         // Streamable HTTP GET stream for server-initiated notifications.
@@ -589,7 +610,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     else if (method == "DELETE" && (path == "/mcp" || path == "/mcp/")) {
         // Stateless server: clients cannot terminate sessions explicitly.
         SendHttpResponse(clientSocket, 405,
-            "{\"error\":\"Method Not Allowed\",\"reason\":\"stateless server\"}");
+            "{\"error\":\"Method Not Allowed\",\"reason\":\"stateless server\"}", "application/json", origin);
     }
     else if (method == "POST" &&
              (path == "/message" || path == "/" || path == "/messages" ||
@@ -599,7 +620,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
     }
     else if (method == "GET" && path == "/") {
         // 鍋ュ悍妫€鏌?
-        SendHttpResponse(clientSocket, 200, "{\"status\":\"ok\",\"service\":\"x64dbg-mcp\"}");
+        SendHttpResponse(clientSocket, 200, "{\"status\":\"ok\",\"service\":\"x64dbg-mcp\"}", "application/json", origin);
     }
     else {
         // Escape path for JSON safety to prevent injection
@@ -613,7 +634,7 @@ void MCPHttpServer::HandleHttpRequest(SOCKET clientSocket, const std::string& re
             }
         }
         SendHttpResponse(clientSocket, 404,
-            "{\"error\":\"Not Found\",\"path\":\"" + safePath + "\"}");
+            "{\"error\":\"Not Found\",\"path\":\"" + safePath + "\"}", "application/json", origin);
     }
 }
 
@@ -623,6 +644,7 @@ void MCPHttpServer::HandleSSE(SOCKET clientSocket) {
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: text/event-stream; charset=utf-8\r\n"
         "Cache-Control: no-cache\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
         "Connection: keep-alive\r\n"
         "\r\n";
 
@@ -1269,7 +1291,8 @@ bool MCPHttpServer::ValidateCrossOriginAndHost(const std::string& origin, const 
 
 void MCPHttpServer::SendHttpResponse(SOCKET socket, int statusCode,
                                      const std::string& body,
-                                     const std::string& contentType) {
+                                     const std::string& contentType,
+                                     const std::string& origin) {
     const std::string responseBody = (statusCode == 204) ? "" : body;
     const char* statusText = GetHttpStatusText(statusCode);
     std::string responseContentType = contentType;
@@ -1283,8 +1306,12 @@ void MCPHttpServer::SendHttpResponse(SOCKET socket, int statusCode,
     std::ostringstream response;
     response << "HTTP/1.1 " << statusCode << " " << statusText << "\r\n"
              << "Content-Type: " << responseContentType << "\r\n"
-             << "Content-Length: " << responseBody.length() << "\r\n"
-             << "Connection: close\r\n"
+             << "Content-Length: " << responseBody.length() << "\r\n";
+    if (!origin.empty()) {
+        response << "Access-Control-Allow-Origin: " << origin << "\r\n"
+                 << "Vary: Origin\r\n";
+    }
+    response << "Connection: close\r\n"
              << "\r\n"
              << responseBody;
     
@@ -1412,7 +1439,7 @@ MCPHttpServer::MCPToolCallResult MCPHttpServer::CallMCPTool(const std::string& t
 // Stateless: no Mcp-Session-Id, no DELETE-driven session termination.
 // =============================================================================
 
-void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body) {
+void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body, const std::string& origin) {
     Logger::Debug("[Streamable HTTP] POST body: " + body);
 
     try {
@@ -1420,7 +1447,8 @@ void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::str
     } catch (const nlohmann::json::exception&) {
         Logger::Error("[Streamable HTTP] Failed to parse JSON body");
         SendHttpResponse(clientSocket, 400,
-            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}");
+            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32700,\"message\":\"Parse error\"}}",
+            "application/json", origin);
         return;
     }
 
@@ -1430,7 +1458,8 @@ void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::str
     if (!ParseJsonRpcRequest(body, method, requestId, hasRequestId)) {
         Logger::Error("[Streamable HTTP] Invalid JSON-RPC request");
         SendHttpResponse(clientSocket, 400,
-            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"}}");
+            "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"}}",
+            "application/json", origin);
         return;
     }
 
@@ -1440,12 +1469,12 @@ void MCPHttpServer::HandleStreamableHttpPost(SOCKET clientSocket, const std::str
 
     if (!hasRequestId || response.empty()) {
         // Notification (no id) or fire-and-forget method: 202 Accepted, no body.
-        SendHttpResponse(clientSocket, 202, "");
+        SendHttpResponse(clientSocket, 202, "", "application/json", origin);
         return;
     }
 
     // Request: return JSON-RPC response inline as application/json.
-    SendHttpResponse(clientSocket, 200, response);
+    SendHttpResponse(clientSocket, 200, response, "application/json", origin);
 }
 
 void MCPHttpServer::HandleStreamableHttpStream(SOCKET clientSocket) {
@@ -1453,6 +1482,7 @@ void MCPHttpServer::HandleStreamableHttpStream(SOCKET clientSocket) {
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: text/event-stream; charset=utf-8\r\n"
         "Cache-Control: no-cache\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
         "Connection: keep-alive\r\n"
         "\r\n";
 

--- a/src/communication/MCPHttpServer.h
+++ b/src/communication/MCPHttpServer.h
@@ -65,17 +65,19 @@ private:
     void HandleHttpRequest(SOCKET clientSocket, const std::string& request);
     
     // 处理 SSE 连接
-    void HandleSSE(SOCKET clientSocket);
+    void HandleSSE(SOCKET clientSocket, const std::string& origin);
 
     // 处理 POST 消息
-    void HandlePostMessage(SOCKET clientSocket, const std::string& body);
+    void HandlePostMessage(SOCKET clientSocket, const std::string& body,
+                           const std::string& origin);
 
     // Streamable HTTP transport (MCP 2025-03-26) — single endpoint /mcp.
     // POST returns the JSON-RPC response inline as application/json.
     // GET opens a long-lived SSE stream used only for server-to-client pushes
     // (no endpoint event handshake, unlike the legacy /sse transport).
-    void HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body, const std::string& origin = "");
-    void HandleStreamableHttpStream(SOCKET clientSocket);
+    void HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body,
+                                  const std::string& origin);
+    void HandleStreamableHttpStream(SOCKET clientSocket, const std::string& origin);
     
     // 处理 MCP 方法调用
     std::string HandleMCPMethod(const std::string& method, const std::string& requestId, const std::string& body);

--- a/src/communication/MCPHttpServer.h
+++ b/src/communication/MCPHttpServer.h
@@ -74,7 +74,7 @@ private:
     // POST returns the JSON-RPC response inline as application/json.
     // GET opens a long-lived SSE stream used only for server-to-client pushes
     // (no endpoint event handshake, unlike the legacy /sse transport).
-    void HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body);
+    void HandleStreamableHttpPost(SOCKET clientSocket, const std::string& body, const std::string& origin = "");
     void HandleStreamableHttpStream(SOCKET clientSocket);
     
     // 处理 MCP 方法调用
@@ -97,7 +97,8 @@ private:
     
     // 发送 HTTP 响应
     void SendHttpResponse(SOCKET socket, int statusCode, const std::string& body,
-                         const std::string& contentType = "application/json");
+                         const std::string& contentType = "application/json",
+                         const std::string& origin = "");
     
     // 发送 SSE 事件
     bool SendSSEEvent(SOCKET socket, const std::string& event, const std::string& data);


### PR DESCRIPTION
## 问题

MCP Inspector Web UI 等浏览器端客户端无法连接 x64dbg-mcp。浏览器发 `OPTIONS /mcp` 预检请求时，服务端未处理 OPTIONS，返回 404 且无 CORS 头，浏览器拦截实际 POST。

## 修复

1. **OPTIONS 预检处理器** — 返回 204 + CORS 头，Origin 在路由前校验
2. **SendHttpResponse** — origin 非空时追加 `Access-Control-Allow-Origin` + `Vary: Origin`
3. **SSE/Stream 流响应** — 补 `Access-Control-Allow-Origin: *`（Origin 已校验）

## 文件变更

- `src/communication/MCPHttpServer.h` — SendHttpResponse / HandleStreamableHttpPost 新增 origin 参数
- `src/communication/MCPHttpServer.cpp` — OPTIONS handler, ACAO 传播, SSE/Stream CORS 头
