### PR TITLE
fix: use GuiUpdateAllViews for older x64dbg compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build directories
 build_x64/
 build_x86/
+build_*/
 build/
 bin/
 lib/

--- a/src/business/DebugController.cpp
+++ b/src/business/DebugController.cpp
@@ -570,7 +570,7 @@ void DebugController::PumpGuiMessages() {
     // DbgUpdateGui is documented as thread-safe by the x64dbg SDK. PeekMessage
     // with nullptr HWND dispatches only messages for the calling thread, which
     // is fine for interop with x64dbg's command queue processing.
-    DbgUpdateGui(0, false);
+    GuiUpdateAllViews();
 
     HWND hwnd = GuiGetWindowHandle();
     if (hwnd == nullptr) {


### PR DESCRIPTION
## Summary
Fixes plugin load failure (`ERROR_PROC_NOT_FOUND`) on x64dbg/x32dbg builds from 2023.

## Problem
`DebugController::PumpGuiMessages()` called `DbgUpdateGui(0, false)`, which is not exported by `x64bridge.dll`/`x32bridge.dll` in older x64dbg builds (e.g. 2023-08-27). Windows fails to resolve the import when loading the plugin, so x64dbg silently skips the plugin and no menu entry appears.

## Fix
- Replace `DbgUpdateGui(0, false)` with `GuiUpdateAllViews()` - available in both old and new x64dbg SDK/bridge exports.
- Add `build_*/` to `.gitignore` to cover alternate CMake build output directories.

## Verification
- Plugin imports fully resolve against 2023 x64dbg/x32dbg (0 missing symbols).
- `LoadLibrary` succeeds in a 64-bit host process.
- 12/12 unit tests pass for x64 and x86.